### PR TITLE
add ability to generate securerandom source for "math/rand" package

### DIFF
--- a/securerandom.go
+++ b/securerandom.go
@@ -26,6 +26,7 @@ package securerandom
 import (
 	crand "crypto/rand"
 	"encoding/base64"
+	mrand "math/rand"
 )
 
 // Bytes is a function that takes an integer and returns
@@ -180,4 +181,17 @@ func Int64() (int64, error) {
 	}
 
 	return i64, nil
+}
+
+// RandSource is a function that returns a Source from the "math/rand" package
+// to be used to create a new pseudorandom generator. If this returns err != nil
+// the value of the source is not suitable for use.
+func RandSource() (mrand.Source, error) {
+	randInt64, err := Int64()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return mrand.NewSource(randInt64), nil
 }

--- a/securerandom_test.go
+++ b/securerandom_test.go
@@ -5,6 +5,7 @@
 package securerandom_test
 
 import (
+	mrand "math/rand"
 	"testing"
 
 	"github.com/theckman/go-securerandom"
@@ -17,6 +18,11 @@ type TestSuite struct{}
 var _ = Suite(&TestSuite{})
 
 func Test(t *testing.T) { TestingT(t) }
+
+// noop is a function so that we can assert the type of a value
+// returned from a function without causing the compiler to complain
+// because we aren't using the variable in a meaningful way
+func noop(interface{}) {}
 
 func (*TestSuite) TestBytes(c *C) {
 	// I have no fucking idea how to test this shit...
@@ -89,8 +95,6 @@ func (t *TestSuite) BenchmarkURLBase64(c *C) {
 		c.SetBytes(int64(len(s)))
 	}
 }
-
-func noop(interface{}) {}
 
 func (t *TestSuite) TestUint16(c *C) {
 	var u16 uint16
@@ -185,5 +189,20 @@ func (t *TestSuite) BenchmarkInt64(c *C) {
 	for i := 0; i < c.N; i++ {
 		securerandom.Uint64()
 		c.SetBytes(8)
+	}
+}
+
+func (*TestSuite) TestRandSource(c *C) {
+	var src mrand.Source
+	var err error
+
+	src, err = securerandom.RandSource()
+	c.Assert(err, IsNil)
+	noop(src)
+}
+
+func (*TestSuite) BenchmarkRandSource(c *C) {
+	for i := 0; i < c.N; i++ {
+		securerandom.RandSource()
 	}
 }


### PR DESCRIPTION
This change adds the ability to return a `math/rand.Source` seeded by securerandom data retrieved from the `crypto/rand` package.
