### PR TITLE
generation of a string from N bytes of securerandom data; v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Full usage information can be found on the [GoDoc](https://godoc.org/github.com/
 
 ```Go
 import (
+	"fmt"
 	"math/rand"
 	"github.com/theckman/go-securerandom"
 )
@@ -26,4 +27,21 @@ if err != nil {
 }
 
 rand.Seed(ri64)
+```
+
+You can also generate random base64 encoded strings from this package:
+
+```Go
+// generate string from 32 random bytes
+rStr, err := securerandom.Base64OfBytes(32)
+
+// secure-random data is unavailable
+if err != nil { /* handle err */ }
+
+fmt.Println(rStr)
+
+// assume your random string can only be 32 bytes long
+rStr, _ = securerandom.Base64InBytes(32)
+
+fmt.Println(rStr) // would print Base64 string with a length of 32
 ```

--- a/securerandom.go
+++ b/securerandom.go
@@ -17,10 +17,24 @@
 // 		ri64, err := securerandom.Int64()
 //
 // 		// secure-random data is unavailable
-// 		if err != nil {
-// 			// handle err
-// 		}
+// 		if err != nil { /* handle err */ }
+//
 //		rand.Seed(ri64)
+//
+// You can also generate random base64 encoded strings from this package:
+//
+//		// generate string from 32 random bytes
+//		rStr, err := securerandom.Base64OfBytes(32)
+//
+//		// secure-random data is unavailable
+//		if err != nil { /* handle err */ }
+//
+// 		fmt.Println(rStr)
+//
+//		// assume your random string can only be 32 bytes long
+//		rStr, _ = securerandom.Base64InBytes(32)
+//
+// 		fmt.Println(rStr) // would print Base64 string with a length of 32
 package securerandom
 
 import (
@@ -28,6 +42,9 @@ import (
 	"encoding/base64"
 	mrand "math/rand"
 )
+
+// PackageVersion is the semantic version number of this package.
+const PackageVersion = "0.1.0"
 
 // Bytes is a function that takes an integer and returns
 // a slice of that length containing random bytes.
@@ -47,19 +64,35 @@ func maximumBytes(size int) int {
 	return int((float64(size) / 4) * 3)
 }
 
-// Base64 is a function that returns a randomize standard Base64
+// Base64InBytes is a function that returns a randomized standard Base64
 // string. This does not use the URL encoding. It takes a single parameter that
 // is the maximum possible length of the string, it will get as close as possible.
-func Base64(max int) (string, error) {
+func Base64InBytes(max int) (string, error) {
 	b, err := Bytes(maximumBytes(max))
 	return base64.StdEncoding.EncodeToString(b), err
 }
 
-// URLBase64 is a function that returns a random URL encoded Base64
+// URLBase64InBytes is a function that returns a random URL encoded Base64
 // string. This does not use the URL encoding. It takes a single parameter that
 // is the maximum possible length of the string, it will get as close as possible.
-func URLBase64(max int) (string, error) {
+func URLBase64InBytes(max int) (string, error) {
 	b, err := Bytes(maximumBytes(max))
+	return base64.URLEncoding.EncodeToString(b), err
+}
+
+// Base64OfBytes is a function that returns a randomized standard Base64
+// string. This does not use the URL encoding. It takes a single parameter that
+// is the number of bytes to used to generate the value.
+func Base64OfBytes(n int) (string, error) {
+	b, err := Bytes(n)
+	return base64.StdEncoding.EncodeToString(b), err
+}
+
+// URLBase64OfBytes is a function that returns a random URL encoded Base64
+// string. This is using URL encoding. It takes a single parameter that
+// is the number of bytes to use to generate the value.
+func URLBase64OfBytes(n int) (string, error) {
+	b, err := Bytes(n)
 	return base64.URLEncoding.EncodeToString(b), err
 }
 

--- a/securerandom_test.go
+++ b/securerandom_test.go
@@ -62,36 +62,70 @@ func (t *TestSuite) BenchmarkBytesBy64(c *C) {
 	}
 }
 
-func (*TestSuite) TestBase64(c *C) {
+func (*TestSuite) TestBase64InBytes(c *C) {
 	var s string
 	var err error
 
-	s, err = securerandom.Base64(32)
+	s, err = securerandom.Base64InBytes(32)
 	c.Assert(err, IsNil)
 	c.Check(len(s), Equals, 32)
 }
 
-func (t *TestSuite) BenchmarkBase64(c *C) {
+func (t *TestSuite) BenchmarkBase64InBytes(c *C) {
 	var s string
 	for i := 0; i < c.N; i++ {
-		s, _ = securerandom.Base64(16)
+		s, _ = securerandom.Base64InBytes(16)
 		c.SetBytes(int64(len(s)))
 	}
 }
 
-func (*TestSuite) TestURLBase64(c *C) {
+func (*TestSuite) TestURLBase64InBytes(c *C) {
 	var s string
 	var err error
 
-	s, err = securerandom.URLBase64(32)
+	s, err = securerandom.URLBase64InBytes(32)
 	c.Assert(err, IsNil)
 	c.Check(len(s), Equals, 32)
 }
 
-func (t *TestSuite) BenchmarkURLBase64(c *C) {
+func (t *TestSuite) BenchmarkURLBase64In(c *C) {
 	var s string
 	for i := 0; i < c.N; i++ {
-		s, _ = securerandom.URLBase64(16)
+		s, _ = securerandom.URLBase64InBytes(16)
+		c.SetBytes(int64(len(s)))
+	}
+}
+
+func (*TestSuite) TestBase64OfBytes(c *C) {
+	var s string
+	var err error
+
+	s, err = securerandom.Base64OfBytes(32)
+	c.Assert(err, IsNil)
+	c.Check(len(s), Equals, 44)
+}
+
+func (t *TestSuite) BenchmarkBase64OfBytes(c *C) {
+	var s string
+	for i := 0; i < c.N; i++ {
+		s, _ = securerandom.Base64OfBytes(16)
+		c.SetBytes(int64(len(s)))
+	}
+}
+
+func (*TestSuite) TestURLBase64OfBytes(c *C) {
+	var s string
+	var err error
+
+	s, err = securerandom.URLBase64OfBytes(32)
+	c.Assert(err, IsNil)
+	c.Check(len(s), Equals, 44)
+}
+
+func (t *TestSuite) BenchmarkURLBase64OfBytes(c *C) {
+	var s string
+	for i := 0; i < c.N; i++ {
+		s, _ = securerandom.URLBase64OfBytes(16)
 		c.SetBytes(int64(len(s)))
 	}
 }


### PR DESCRIPTION
This change enhances the package to allow generation of Base64-encoded strings from a specified number of securerandom bytes. To accomplish this, the `Base64` and `URLBase64` functions were renamed to `Base64InBytes` and `URLBase64InBytes`, respectably. They return a string that should fit within the number of bytes provided to those functions. The new functions, `Base64OfBytes` and `URLBase64OfBytes`, generate a Base64 string from the number of bytes you specify. You can use the following calculation to determine how long the Base64-encoded string will be: `(math.Floor(N / 3.0) + 1) * 4`
