### PR TITLE
remove alias from math/rand import

### DIFF
--- a/securerandom.go
+++ b/securerandom.go
@@ -40,7 +40,7 @@ package securerandom
 import (
 	crand "crypto/rand"
 	"encoding/base64"
-	mrand "math/rand"
+	"math/rand"
 )
 
 // PackageVersion is the semantic version number of this package.
@@ -219,12 +219,12 @@ func Int64() (int64, error) {
 // RandSource is a function that returns a Source from the "math/rand" package
 // to be used to create a new pseudorandom generator. If this returns err != nil
 // the value of the source is not suitable for use.
-func RandSource() (mrand.Source, error) {
+func RandSource() (rand.Source, error) {
 	randInt64, err := Int64()
 
 	if err != nil {
 		return nil, err
 	}
 
-	return mrand.NewSource(randInt64), nil
+	return rand.NewSource(randInt64), nil
 }

--- a/securerandom_test.go
+++ b/securerandom_test.go
@@ -5,7 +5,7 @@
 package securerandom_test
 
 import (
-	mrand "math/rand"
+	"math/rand"
 	"testing"
 
 	"github.com/theckman/go-securerandom"
@@ -227,7 +227,7 @@ func (t *TestSuite) BenchmarkInt64(c *C) {
 }
 
 func (*TestSuite) TestRandSource(c *C) {
-	var src mrand.Source
+	var src rand.Source
 	var err error
 
 	src, err = securerandom.RandSource()


### PR DESCRIPTION
Because we return something from the `math/rand` package (`rand.Source`), we should probably not use an import alias to avoid making the documentation confusing. This removes the `mrand` alias for `math/rand`, and updates any code that used it.
